### PR TITLE
[AE-1668] separate hadoop and hive jars

### DIFF
--- a/conf/spark-env.sh
+++ b/conf/spark-env.sh
@@ -7,9 +7,12 @@
 JAVA_HOME=/usr/java/default
 
 # This file is sourced when running various Spark programs.
-# Copy it as spark-env.sh and edit that to configure Spark for your site.
+# Copy it as spark-env.sh and edit it to configure Spark for your site.
 if [ "x${SPARK_VERSION}" = "x" ] ; then
   SPARK_VERSION="1.6.0"
+fi
+if [ "x${SPARK_HOME}" = "x" ] ; then
+  SPARK_HOME="/opt/spark"
 fi
 
 # - SPARK_CLASSPATH, default classpath entries to append
@@ -52,7 +55,9 @@ fi
 # SPARK_YARN_DIST_FILES=/user/spark/opt/hadoop/share/hadoop/hdfs/hadoop-hdfs-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-client-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-common-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-api-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-server-web-proxy-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-app-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-jobclient-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-core-2.4.1.jar
 # - SPARK_YARN_DIST_ARCHIVES, Comma separated list of archives to be distributed with the job.
 # See docs/hadoop-provided.md
-HIVE_JAR_COMMA_LIST=""
+SPARK_HIVE_JAR=$(basename $SPARK_HOME/sql/hive/target/spark-hive_2.10-${SPARK_VERSION}.jar)
+SPARK_HIVETHRIFT_JAR=$(basename $SPARK_HOME/sql/hive-thriftserver/target/spark-hive-thriftserver_2.10-${SPARK_VERSION}.jar)
+HIVE_JAR_COMMA_LIST="$SPARK_HIVE_JAR:$SPARK_HIVETHRIFT_JAR"
 for f in `find /opt/hive/lib/ -type f -name "*.jar"`
 do
   HIVE_JAR_COMMA_LIST=$(basename $f):$HIVE_JAR_COMMA_LIST

--- a/conf/spark-env.sh
+++ b/conf/spark-env.sh
@@ -52,4 +52,10 @@ fi
 # SPARK_YARN_DIST_FILES=/user/spark/opt/hadoop/share/hadoop/hdfs/hadoop-hdfs-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-client-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-common-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-api-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-server-web-proxy-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-app-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-jobclient-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-core-2.4.1.jar
 # - SPARK_YARN_DIST_ARCHIVES, Comma separated list of archives to be distributed with the job.
 # See docs/hadoop-provided.md
-export SPARK_DIST_CLASSPATH=$(hadoop classpath)
+HIVE_JAR_COMMA_LIST=""
+for f in `find /opt/hive/lib/ -type f -name "*.jar"`
+do
+  HIVE_JAR_COMMA_LIST=$(basename $f):$HIVE_JAR_COMMA_LIST
+done
+
+export SPARK_DIST_CLASSPATH=$(hadoop classpath):$HIVE_JAR_COMMA_LIST


### PR DESCRIPTION
Add JAR name to classpath for executor defined by `SPARK_DIST_CLASSPATH`. 
If you provide the full path here, it will not work since the JARs are deployed to the working directory under `.`, unless you re-create the directory path such as `/opt/hive/lib/` and `/opt/spark/sql/hive/`, etc.

The approach is to have the application itself to utilize the `spark.executor.extraClassPath` and `spark.yarn.dist.files`. See: http://spark.apache.org/docs/latest/running-on-yarn.html#configuration
