### PR TITLE
HT-483: Fix all test case to work with Hadoop and Hive JAR provided by spark-env.sh

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -35,9 +35,9 @@ else
 fi
 
 # Find assembly jar
-SPARK_ASSEMBLY_JAR=
-if [ -f "$SPARK_HOME/RELEASE" ]; then
-  ASSEMBLY_DIR="$SPARK_HOME/lib"
+SPARK_ASSEMBLY_JAR="${SPARK_HOME}/lib/spark-assembly-${SPARK_VERSION}.jar"
+if [ -f "${SPARK_HOME}/RELEASE" ]; then
+  ASSEMBLY_DIR="${SPARK_HOME}/lib"
 else
   ASSEMBLY_DIR="$SPARK_HOME/assembly/target/scala-$SPARK_SCALA_VERSION"
 fi
@@ -57,7 +57,7 @@ if [ "$num_jars" -gt "1" ]; then
   exit 1
 fi
 
-SPARK_ASSEMBLY_JAR="${ASSEMBLY_DIR}/${ASSEMBLY_JARS}"
+SPARK_ASSEMBLY_JAR=${SPARK_ASSEMBLY_JAR:-"$ASSEMBLY_DIR/$ASSEMBLY_JARS"}
 
 LAUNCH_CLASSPATH="$SPARK_ASSEMBLY_JAR"
 

--- a/conf/executor-log4j.properties
+++ b/conf/executor-log4j.properties
@@ -1,0 +1,108 @@
+# Define some default values that can be overridden by system properties
+spark.log.threshold=ALL
+spark.root.logger=INFO, DRFA
+spark.log.dir=${spark.yarn.app.container.log.dir}
+spark.log.file=spark-executor-1.5.2.log
+
+# Define the root logger to the application property spark.root.logger
+log4j.rootLogger=${spark.root.logger}
+log4j.rootCategory=WARN, console
+# Logging Threshold
+log4j.threshold=${spark.log.threshold}
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+###############################
+# Daily Rolling File Appender #
+###############################
+# Use the PidDailyerRollingFileAppend class instead if you want to use separate log files
+# for different CLI session.
+#
+# log4j.appender.DRFA=org.apache.hadoop.spark.ql.log.PidDailyRollingFileAppender
+log4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.DRFA.File=${spark.log.dir}/${spark.log.file}
+# Rollver at midnight
+log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
+# 30-day backup
+#log4j.appender.DRFA.MaxBackupIndex=30
+log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
+# Pattern format: Date LogLevel LoggerName LogMessage
+#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+# Debugging Pattern format
+# log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+# We want to print out the full classpath + pkg name for troubleshooting
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+
+####################
+# Console Appender #
+####################
+# Set everything to be logged to the console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.threshold=WARN
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+log4j.appender.console.encoding=UTF-8
+
+log4j.appender.spark=org.apache.log4j.ConsoleAppender
+log4j.appender.spark.threshold=INFO
+log4j.appender.spark.target=System.err
+log4j.appender.spark.layout=org.apache.log4j.PatternLayout
+log4j.appender.spark.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+log4j.appender.spark.encoding=UTF-8
+
+log4j.appender.sparkyarn=org.apache.log4j.ConsoleAppender
+log4j.appender.sparkyarn.threshold=INFO
+log4j.appender.sparkyarn.target=System.err
+log4j.appender.sparkyarn.layout=org.apache.log4j.PatternLayout
+log4j.appender.sparkyarn.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+log4j.appender.sparkyarn.encoding=UTF-8
+
+log4j.appender.sparkhivethrift=org.apache.log4j.ConsoleAppender
+log4j.appender.sparkhivethrift.threshold=INFO
+log4j.appender.sparkhivethrift.target=System.err
+log4j.appender.sparkhivethrift.layout=org.apache.log4j.PatternLayout
+log4j.appender.sparkhivethrift.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+log4j.appender.sparkhivethrift.encoding=UTF-8
+
+log4j.appender.hivecli=org.apache.log4j.ConsoleAppender
+log4j.appender.hivecli.threshold=INFO
+log4j.appender.hivecli.target=System.err
+log4j.appender.hivecli.layout=org.apache.log4j.PatternLayout
+log4j.appender.hivecli.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+log4j.appender.hivecli.encoding=UTF-8
+
+log4j.category.DataNucleus=ERROR,console
+log4j.category.Datastore=ERROR,console
+log4j.category.Datastore.Schema=ERROR,console
+log4j.category.JPOX.Datastore=ERROR,console
+log4j.category.JPOX.Plugin=ERROR,console
+log4j.category.JPOX.MetaData=ERROR,console
+log4j.category.JPOX.Query=ERROR,console
+log4j.category.JPOX.General=ERROR,console
+log4j.category.JPOX.Enhancer=ERROR,console
+
+log4j.logger.org.apache.hadoop.hive.cli.OptionsProcessor=WARN, console
+
+log4j.additivity.org.apache.spark.deploy=false
+log4j.additivity.org.apache.spark.deploy.yarn=false
+log4j.additivity.org.apache.spark.repl=false
+log4j.additivity.org.apache.hadoop.util=false
+log4j.additivity.org.apache.hadoop.hive.cli=false
+log4j.additivity.org.apache.spark.sql.hive.thriftserver=false
+log4j.logger.org.apache.spark.deploy=INFO, spark
+log4j.logger.org.apache.spark.deploy.yarn=INFO, sparkyarn
+log4j.logger.org.apache.spark.repl=INFO, console
+log4j.logger.org.apache.hadoop.util=INFO, console
+log4j.logger.org.apache.hadoop.hive.cli=INFO, hivecli
+log4j.logger.org.apache.spark.sql.hive.thriftserver=INFO, sparkhivethrift

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -1,69 +1,48 @@
 # Define some default values that can be overridden by system properties
 spark.log.threshold=ALL
-spark.root.logger=INFO,DRFA
-spark.log.dir=/home/${user.name}/Hadooplogs/spark/logs
-spark.log.file=spark.log
+spark.root.logger=INFO, console
 
-# Define the root logger to the system property "hadoop.root.logger".
-log4j.rootLogger=${spark.root.logger}, EventCounter
+# Define the root logger to the application property spark.root.logger
+log4j.rootLogger=${spark.root.logger}
 log4j.rootCategory=WARN, console
 # Logging Threshold
 log4j.threshold=${spark.log.threshold}
 
 # Settings to quiet third party logs that are too verbose
-log4j.logger.org.eclipse.jetty=WARN
-log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
-log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
-log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
 log4j.logger.org.spark-project.jetty=WARN
 log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
 
-###############################
-# Daily Rolling File Appender #
-###############################
-# Use the PidDailyerRollingFileAppend class instead if you want to use separate log files
-# for different CLI session.
-#
-# log4j.appender.DRFA=org.apache.hadoop.spark.ql.log.PidDailyRollingFileAppender
-log4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.DRFA.File=${spark.log.dir}/${spark.log.file}
-# Rollver at midnight
-log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
-# 30-day backup
-#log4j.appender.DRFA.MaxBackupIndex=30
-log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
-# Pattern format: Date LogLevel LoggerName LogMessage
-#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
-# Debugging Pattern format
-# log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
-# We want to print out the full classpath + pkg name for troubleshooting
-log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
 
 ####################
 # Console Appender #
 ####################
 # Set everything to be logged to the console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.threshold=WARN
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
 log4j.appender.console.encoding=UTF-8
 
-##########################
-# Event Counter Appender #
-##########################
-# Sends counts of logging messages at different severity levels to Hadoop Metrics.
-#
-log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
-
-log4j.category.DataNucleus=ERROR,DRFA
-log4j.category.Datastore=ERROR,DRFA
-log4j.category.Datastore.Schema=ERROR,DRFA
-log4j.category.JPOX.Datastore=ERROR,DRFA
-log4j.category.JPOX.Plugin=ERROR,DRFA
-log4j.category.JPOX.MetaData=ERROR,DRFA
-log4j.category.JPOX.Query=ERROR,DRFA
-log4j.category.JPOX.General=ERROR,DRFA
-log4j.category.JPOX.Enhancer=ERROR,DRFA
-
-
+# log4j.additivity.org.apache.spark.deploy=false
+# log4j.additivity.org.apache.spark.deploy.yarn=false
+# log4j.additivity.org.apache.spark.repl=false
+# log4j.additivity.org.apache.hadoop.util=false
+# log4j.additivity.org.apache.hadoop.yarn.client.api.impl=false
+# log4j.additivity.org.apache.hadoop.hive.cli=false
+# log4j.additivity.org.apache.spark.sql.hive.thriftserver=false
+# log4j.logger.org.apache.spark.deploy=INFO, spark
+# log4j.logger.org.apache.spark.deploy.yarn=INFO, sparkyarn
+# log4j.logger.org.apache.spark.repl=INFO, console
+# log4j.logger.org.apache.hadoop.util=INFO, console
+# log4j.logger.org.apache.hadoop.hive.cli=INFO, hivecli
+# log4j.logger.org.apache.spark.sql.hive.thriftserver=INFO, sparkhivethrift
+# log4j.logger.org.apache.hadoop.yarn.client.api.impl=INFO, console
+# log4j.logger.org.apache.hadoop.util=INFO, console

--- a/conf/spark-defaults.conf
+++ b/conf/spark-defaults.conf
@@ -1,17 +1,13 @@
 # Default system properties included when running spark-submit.
 # This is useful for setting default environmental settings.
 
-# Example:
-# spark.master            spark://master:7077
-# spark.history.provider               org.apache.spark.deploy.history.FsHistoryProvider
 spark.eventLog.enabled               true
-spark.eventLog.dir                   hdfs:///logs/spark-history/
-spark.history.fs.logDirectory        hdfs:///logs/spark-history/
+spark.eventLog.dir                   hdfs:///logs/spark-history
+spark.history.fs.logDirectory        hdfs:///logs/spark-history
 spark.history.retainedApplications   9999999
 spark.history.ui.port                18080
 spark.logConf                        true
-spark.executor.extraJavaOptions      "-Djava.library.path=/opt/hadoop/lib/native/"
-# spark.serializer        org.apache.spark.serializer.KryoSerializer
+spark.serializer                     org.apache.spark.serializer.KryoSerializer
 spark.port.maxRetries                999
 spark.ui.port                        45100
 spark.driver.port                    45055
@@ -20,6 +16,7 @@ spark.executor.port                  45250
 spark.fileserver.port                45090
 spark.broadcast.port                 45200
 spark.blockManager.port              45300
+# spark.yarn.jar                       hdfs:///apps/spark/1.5.2/libs/spark-assembly.jar
 
 # The following options are for Spark Streaming. If small files are accumulating, it will
 # impact Spark performance, consolidate the files will reduce the files during shuffle phase
@@ -27,4 +24,16 @@ spark.blockManager.port              45300
 # on long running spark jobs such as Spark Streaming jobs.
 # Default: false (but set to true in Altiscale for ext4 support)
 # See: http://www.cs.berkeley.edu/~kubitron/courses/cs262a-F13/projects/reports/project16_report.pdf
-spark.shuffle.consolidateFiles true
+# spark.shuffle.consolidateFiles     true
+
+# We have to change the chef code to change our configuration file for spark.yarn.dist.jars
+# Customer can override the following parameter on runtime
+spark.master                          yarn
+spark.submit.deployMode               client
+spark.driver.memory                   512M
+spark.executor.memory                 1G
+spark.executor.cores                  2
+
+spark.yarn.dist.files                 /etc/alti-spark-1.5.2/yarnclient-driver-log4j.properties,/etc/alti-spark-1.5.2/yarncluster-driver-log4j.properties,/etc/alti-spark-1.5.2/executor-log4j.properties
+
+spark.executor.extraJavaOptions      -Dlog4j.configuration=executor-log4j.properties -XX:+PrintReferenceGC -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintAdaptiveSizePolicy -Djava.library.path=/opt/hadoop/lib/native/

--- a/conf/spark-env.sh
+++ b/conf/spark-env.sh
@@ -4,13 +4,16 @@
 # WARNING: STANDALONE and MESOS are NOT supported in your Infrastructure #
 ##########################################################################
 
-JAVA_HOME=/usr/java/default
+JAVA_HOME=${JAVA_HOME:-"/usr/java/default"}
 
 # This file is sourced when running various Spark programs.
-# Copy it as spark-env.sh and edit that to configure Spark for your site.
-if [ "x${SPARK_VERSION}" = "x" ] ; then
-  SPARK_VERSION="1.5.2"
-fi
+# Copy it as spark-env.sh and edit it to configure Spark for your site.
+# We honor bin/load-spark-env.sh values, and any external assignment from
+# users.
+export SPARK_VERSION=${SPARK_VERSION:-"1.5.2"}
+# Use absolute path here, do NOT apply /opt/spark here since we need to support multiple version of Spark
+export SPARK_HOME=${SPARK_HOME:-"/opt/alti-spark-1.5.2"}
+export SPARK_SCALA_VERSION=${SPARK_SCALA_VERSION:-"2.10"}
 
 # - SPARK_CLASSPATH, default classpath entries to append
 # Altiscale local libs and folders
@@ -18,37 +21,20 @@ fi
 # - SPARK_LOCAL_DIRS, storage directories to use on this node for shuffle and RDD data
 
 # Options read in YARN client mode
-HADOOP_HOME=/opt/hadoop/
-HIVE_HOME=/opt/hive/
+HADOOP_HOME=${HADOOP_HOME:-"/opt/hadoop/"}
+HIVE_HOME=${HIVE_HOME:-"/opt/hive/"}
 # - HADOOP_CONF_DIR, to point Spark towards Hadoop configuration files
-HADOOP_CONF_DIR=/etc/hadoop/
-YARN_CONF_DIR=/etc/hadoop/
+HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-"/etc/hadoop/"}
+YARN_CONF_DIR=${YARN_CONF_DIR:-"/etc/hadoop/"}
 
-HADOOP_SNAPPY_JAR=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-HADOOP_LZO_JAR=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-
-export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$HADOOP_HOME/lib/native
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/lib/native
-export SPARK_LIBRARY_PATH=$SPARK_LIBRARY_PATH:$HADOOP_HOME/lib/native
-export MYSQL_JDBC_DRIVER=/opt/mysql-connector/mysql-connector.jar
-export HIVE_TEZ_JARS=""
-if [ -f /etc/tez/tez-site.xml ] ; then
-  HIVE_TEZ_JARS=$(find /opt/tez/ -type f -name "*.jar" | tr -s "\n" ":" | sed 's/:$//')
-fi
+# export HIVE_TEZ_JARS=""
+# if [ -f /etc/tez/tez-site.xml ] ; then
+#   HIVE_TEZ_JARS=$(find /opt/tez/ -type f -name "*.jar" | tr -s "\n" ":" | sed 's/:$//')
+# fi
 
-# OBSOLETE
-# DO NOT USE SPARK_CLASSPATH anymore since it conflict in yarn-client mode with --driver-class-path
-# Use --jars and --driver-class-path in the future for compatibility on both yarn-client and yarn-cluster mode
-# See test_spark_shell.sh and test_spark_hql.sh for examples
-# export SPARK_CLASSPATH=$SPARK_CLASSPATH:$HADOOP_SNAPPY_JAR:$HADOOP_LZO_JAR:$MYSQL_JDBC_DRIVER:$HIVE_TEZ_JARS
+# See docs/hadoop-provided.md
+SPARK_HIVE_JAR=$SPARK_HOME/lib/spark-hive_${SPARK_SCALA_VERSION}.jar
+SPARK_HIVETHRIFT_JAR=$SPARK_HOME/lib/spark-hive-thriftserver_${SPARK_SCALA_VERSION}.jar
 
-# - SPARK_EXECUTOR_INSTANCES, Number of workers to start (Default: 2)
-# - SPARK_EXECUTOR_CORES, Number of cores for the workers (Default: 1).
-# - SPARK_EXECUTOR_MEMORY, Memory per Worker (e.g. 1000M, 2G) (Default: 1G)
-# - SPARK_DRIVER_MEMORY, Memory for Master (e.g. 1000M, 2G) (Default: 512 Mb)
-# - SPARK_YARN_APP_NAME, The name of your application (Default: Spark)
-# - SPARK_YARN_QUEUE, The hadoop queue to use for allocation requests (Default: ‘default’)
-# - SPARK_YARN_DIST_FILES, Comma separated list of files to be distributed with the job.
-# SPARK_YARN_DIST_FILES=/user/spark/opt/hadoop/share/hadoop/hdfs/hadoop-hdfs-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-client-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-common-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-api-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/yarn/hadoop-yarn-server-web-proxy-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-app-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-jobclient-2.4.1.jar,/user/spark/opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-client-core-2.4.1.jar
-# - SPARK_YARN_DIST_ARCHIVES, Comma separated list of archives to be distributed with the job.
-
+export SPARK_DIST_CLASSPATH=$(hadoop classpath):$SPARK_HIVE_JAR:$SPARK_HIVETHRIFT_JAR:$(basename $SPARK_HIVE_JAR):$(basename $SPARK_HIVETHRIFT_JAR):${HIVE_HOME}/lib/*:./hive/*

--- a/conf/yarnclient-driver-log4j.properties
+++ b/conf/yarnclient-driver-log4j.properties
@@ -1,0 +1,90 @@
+# Define some default values that can be overridden by system properties
+spark.log.threshold=ALL
+spark.root.logger=INFO ,RFA, console
+spark.log.dir=/home/${user.name}/Hadooplogs/spark/logs
+spark.log.file=spark-driver-1.5.2.log
+
+# Define the root logger to the application property spark.root.logger
+log4j.rootLogger=${spark.root.logger}
+log4j.rootCategory=WARN, RFA
+# Logging Threshold
+log4j.threshold=${spark.log.threshold}
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+
+#########################
+# Rolling File Appender #
+#########################
+log4j.appender.RFA=org.apache.log4j.RollingFileAppender
+log4j.appender.RFA.File=${spark.log.dir}/${spark.log.file}
+log4j.appender.RFA.Append=true
+# 30 files max backup
+log4j.appender.RFA.MaxBackupIndex=30
+log4j.appender.RFA.MaxFileSize=10485760
+log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+# Pattern format: Date LogLevel LoggerName LogMessage
+#log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+# Debugging Pattern format
+# log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+# We want to print out the full classpath + pkg name for troubleshooting
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+
+####################
+# Console Appender #
+####################
+# Set everything to be logged to the console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.threshold=WARN
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+log4j.appender.console.encoding=UTF-8
+
+# log4j.appender.spark=org.apache.log4j.ConsoleAppender
+# log4j.appender.spark.threshold=INFO
+# log4j.appender.spark.target=System.err
+# log4j.appender.spark.layout=org.apache.log4j.PatternLayout
+# log4j.appender.spark.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.spark.encoding=UTF-8
+# 
+# log4j.appender.sparkyarn=org.apache.log4j.ConsoleAppender
+# log4j.appender.sparkyarn.threshold=INFO
+# log4j.appender.sparkyarn.target=System.err
+# log4j.appender.sparkyarn.layout=org.apache.log4j.PatternLayout
+# log4j.appender.sparkyarn.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.sparkyarn.encoding=UTF-8
+# 
+# log4j.appender.sparkhivethrift=org.apache.log4j.ConsoleAppender
+# log4j.appender.sparkhivethrift.threshold=INFO
+# log4j.appender.sparkhivethrift.target=System.err
+# log4j.appender.sparkhivethrift.layout=org.apache.log4j.PatternLayout
+# log4j.appender.sparkhivethrift.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.sparkhivethrift.encoding=UTF-8
+# 
+# log4j.appender.hivecli=org.apache.log4j.ConsoleAppender
+# log4j.appender.hivecli.threshold=INFO
+# log4j.appender.hivecli.target=System.err
+# log4j.appender.hivecli.layout=org.apache.log4j.PatternLayout
+# log4j.appender.hivecli.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.hivecli.encoding=UTF-8
+
+log4j.category.DataNucleus=ERROR,RFA
+log4j.category.Datastore=ERROR,RFA
+log4j.category.Datastore.Schema=ERROR,RFA
+log4j.category.JPOX.Datastore=ERROR,RFA
+log4j.category.JPOX.Plugin=ERROR,RFA
+log4j.category.JPOX.MetaData=ERROR,RFA
+log4j.category.JPOX.Query=ERROR,RFA
+log4j.category.JPOX.General=ERROR,RFA
+log4j.category.JPOX.Enhancer=ERROR,RFA

--- a/conf/yarncluster-driver-log4j.properties
+++ b/conf/yarncluster-driver-log4j.properties
@@ -1,0 +1,90 @@
+# Define some default values that can be overridden by system properties
+spark.log.threshold=ALL
+spark.root.logger=INFO ,RFA, console
+spark.log.dir=${spark.yarn.app.container.log.dir}
+spark.log.file=spark-driver-1.5.2.log
+
+# Define the root logger to the application property spark.root.logger
+log4j.rootLogger=${spark.root.logger}
+log4j.rootCategory=WARN, RFA
+# Logging Threshold
+log4j.threshold=${spark.log.threshold}
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+
+#########################
+# Rolling File Appender #
+#########################
+log4j.appender.RFA=org.apache.log4j.RollingFileAppender
+log4j.appender.RFA.File=${spark.log.dir}/${spark.log.file}
+log4j.appender.RFA.Append=true
+# 30 files max backup
+log4j.appender.RFA.MaxBackupIndex=30
+log4j.appender.RFA.MaxFileSize=10485760
+log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+# Pattern format: Date LogLevel LoggerName LogMessage
+#log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+# Debugging Pattern format
+# log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+# We want to print out the full classpath + pkg name for troubleshooting
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+
+####################
+# Console Appender #
+####################
+# Set everything to be logged to the console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.threshold=WARN
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+log4j.appender.console.encoding=UTF-8
+
+# log4j.appender.spark=org.apache.log4j.ConsoleAppender
+# log4j.appender.spark.threshold=INFO
+# log4j.appender.spark.target=System.err
+# log4j.appender.spark.layout=org.apache.log4j.PatternLayout
+# log4j.appender.spark.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.spark.encoding=UTF-8
+# 
+# log4j.appender.sparkyarn=org.apache.log4j.ConsoleAppender
+# log4j.appender.sparkyarn.threshold=INFO
+# log4j.appender.sparkyarn.target=System.err
+# log4j.appender.sparkyarn.layout=org.apache.log4j.PatternLayout
+# log4j.appender.sparkyarn.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.sparkyarn.encoding=UTF-8
+# 
+# log4j.appender.sparkhivethrift=org.apache.log4j.ConsoleAppender
+# log4j.appender.sparkhivethrift.threshold=INFO
+# log4j.appender.sparkhivethrift.target=System.err
+# log4j.appender.sparkhivethrift.layout=org.apache.log4j.PatternLayout
+# log4j.appender.sparkhivethrift.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.sparkhivethrift.encoding=UTF-8
+# 
+# log4j.appender.hivecli=org.apache.log4j.ConsoleAppender
+# log4j.appender.hivecli.threshold=INFO
+# log4j.appender.hivecli.target=System.err
+# log4j.appender.hivecli.layout=org.apache.log4j.PatternLayout
+# log4j.appender.hivecli.layout.ConversionPattern=%d{ISO8601} %-5p %c (%F:%M(%L)) - %m%n
+# log4j.appender.hivecli.encoding=UTF-8
+
+log4j.category.DataNucleus=ERROR,RFA
+log4j.category.Datastore=ERROR,RFA
+log4j.category.Datastore.Schema=ERROR,RFA
+log4j.category.JPOX.Datastore=ERROR,RFA
+log4j.category.JPOX.Plugin=ERROR,RFA
+log4j.category.JPOX.MetaData=ERROR,RFA
+log4j.category.JPOX.Query=ERROR,RFA
+log4j.category.JPOX.General=ERROR,RFA
+log4j.category.JPOX.Enhancer=ERROR,RFA


### PR DESCRIPTION
## What changes were proposed in this pull request?

We don't want to specify Hadoop and Hive JARs in spark-submit command, options, etc.

(Please fill in changes proposed in this fix)
We put these into spark-env.sh and spark-defaults.conf so spark-submit command is shorten.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

spark-env.sh and spark-defaults.conf

Backport the following from Spark 1.6.1 to 1.5.2.

AE-2021: Provide smooth upgrade solution, utilize SPARK_HOME/lib
directory for assembly jar without hadoop version string

SI-695: Apply customized log4j properties for yarn-client and
yarn-cluster mode respectively. Default output will point to console
which will be captured by YARN container logs. Spark driver logs will
now go to spark-driver.log and executor logs will go to spark-executor.log.
AE-2048: Update spark-env.sh to include Hive JARs in classpath and
distribute them for both yarn-client and yarn-cluster mode. This still
requires user to upload Hive JARs via the --jars option, however, they
no longer need to specify the lengthy classpath in SparkConf.
