### PR TITLE
Cherry-picking pull request https://github.com//apache/spark/pull/12215

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <curator.version>2.6.0</curator.version>
     <hive.group>org.spark-project.hive</hive.group>
     <!-- Version used in Maven Hive dependency -->
-    <hive.version>1.2.1.spark</hive.version>
+    <hive.version>1.2.1.spark2</hive.version>
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <derby.version>10.10.1.1</derby.version>
@@ -2360,7 +2360,7 @@
       <properties>
         <hadoop.version>2.4.1</hadoop.version>
         <yarn.version>2.4.1</yarn.version>
-        <hive.version>1.2.1.spark</hive.version>
+        <hive.version>1.2.1.spark2</hive.version>
         <hive.version.short>1.2.1</hive.version.short>
         <jets3t.version>0.9.3</jets3t.version>
       </properties>
@@ -2371,7 +2371,7 @@
       <properties>
         <hadoop.version>2.6.0</hadoop.version>
         <yarn.version>2.6.0</yarn.version>
-        <hive.version>1.2.1.spark</hive.version>
+        <hive.version>1.2.1.spark2</hive.version>
         <hive.version.short>1.2.1</hive.version.short>
         <jets3t.version>0.9.3</jets3t.version>
         <zookeeper.version>3.4.6</zookeeper.version>
@@ -2384,7 +2384,7 @@
       <properties>
         <hadoop.version>2.7.1</hadoop.version>
         <yarn.version>2.7.1</yarn.version>
-        <hive.version>1.2.1.spark</hive.version>
+        <hive.version>1.2.1.spark2</hive.version>
         <hive.version.short>1.2.1</hive.version.short>
         <jets3t.version>0.9.3</jets3t.version>
         <zookeeper.version>3.4.6</zookeeper.version>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -27,8 +27,9 @@ import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
-import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.io.{Input, Output}
+import org.apache.hive.com.esotericsoftware.kryo.Kryo
+import org.apache.hive.com.esotericsoftware.kryo.io.{Input, Output}
+import com.google.common.base.Objects
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR updates the HiveShim to use org.apache.hive namespace for the shaded Kryo libraries.
e.g. `org.apache.hive.com.esotericsoftware.kryo.Kryo`

(Please fill in changes proposed in this fix)
This updates the `1.2.1.spark` Hive to `1.2.1.spark2` Hive version to apply such changes and namespace for the shaded Kryo libs.
## How was this patch tested?

CI.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

(https://github.com/apache/spark/pull/12215/commits/8f74c7485886cbe3af4963115a2e9d8225f11693,https://github.com/apache/spark/pull/12215/commits/e2237bd0b82599c068eccf30ff1fe40fe4db694f)
