### PR TITLE
exclude conflicted classes with custom auth in hive-1.2.1

### DIFF
--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -117,6 +117,17 @@
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <configuration>
+	  <!-- exclude the following classes that cause conflict with custom authentication in hive-1.2.1 -->
+          <excludes>
+            <exclude>**/auth/*</exclude>
+            <exclude>**/cli/thrift/*</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?
To exclude the conflicted classes with custom auth in hive-1.2.1. 

## How was this patch tested?
Tested with the jar in foa and server started successfully and able to access hive table.

Please review http://spark.apache.org/contributing.html before opening a pull request.
