### PR TITLE
Fix OperationLog import. Revert ThriftHttpCLIService

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/ExecuteStatementOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/ExecuteStatementOperation.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.hadoop.hive.ql.processors.CommandProcessor;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorFactory;
+import org.apache.hadoop.hive.ql.session.OperationLog;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationType;
 import org.apache.hive.service.cli.session.HiveSession;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix exceptions

```
[error] /Users/i857894/IdeaProjects/sap-branch-2.3.2-alti-SPARK-24570-patch/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/ExecuteStatementOperation.java:79: error: cannot find symbol
[error]       OperationLog.setCurrentOperationLog(operationLog);
[error]       ^
[error]   symbol:   variable OperationLog
[error]   location: class ExecuteStatementOperation
[error] /Users/i857894/IdeaProjects/sap-branch-2.3.2-alti-SPARK-24570-patch/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java:72: error: cannot find symbol
[error]       httpServer.setThreadPool(threadPool);
[error]                 ^
[error]   symbol:   method setThreadPool(ExecutorThreadPool)
[error]   location: variable httpServer of type Server
[error] /Users/i857894/IdeaProjects/sap-branch-2.3.2-alti-SPARK-24570-patch/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java:75: error: cannot find symbol
[error]       SelectChannelConnector connector = new SelectChannelConnector();
[error]       ^
[error]   symbol:   class SelectChannelConnector
[error]   location: class ThriftHttpCLIService
[error] /Users/i857894/IdeaProjects/sap-branch-2.3.2-alti-SPARK-24570-patch/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java:75: error: cannot find symbol
[error]       SelectChannelConnector connector = new SelectChannelConnector();
[error]                                              ^
[error]   symbol:   class SelectChannelConnector
[error]   location: class ThriftHttpCLIService
[error] /Users/i857894/IdeaProjects/sap-branch-2.3.2-alti-SPARK-24570-patch/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java:95: error: cannot find symbol
[error]         connector = new SslSelectChannelConnector(sslContextFactory);
[error]                         ^
[error]   symbol:   class SslSelectChannelConnector
[error]   location: class ThriftHttpCLIService
```

## How was this patch tested?

N/A