### PR TITLE
Make MetadataOperation.DEFAULT_HIVE_CATALOG public for scala sub-class to access

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/MetadataOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/MetadataOperation.java
@@ -40,7 +40,7 @@ import org.apache.hive.service.cli.session.HiveSession;
  */
 public abstract class MetadataOperation extends Operation {
 
-  protected static final String DEFAULT_HIVE_CATALOG = "";
+  public static final String DEFAULT_HIVE_CATALOG = "";
   protected static TableSchema RESULT_SET_SCHEMA;
   private static final char SEARCH_STRING_ESCAPE = '\\';
 


### PR DESCRIPTION
Make DEFAULT_HIVE_CATALOG public for scala code SparkGetSchemasOperation to access from  Java world's MetadataOperation.

This is odd, it was defined as protected in parent class, supposely subclass should be able to access. I'm not sure if
this is a JVM issue or Scala vs JAva bytecode compatible issue. Scala access modifier is different from Java's.
