### PR TITLE
bug(BDSGOLD-900): Fix rpm rename logic

### DIFF
--- a/cfg/export.ads
+++ b/cfg/export.ads
@@ -3,7 +3,7 @@ artifacts builderVersion: "1.1", {
   group "com.sap.bds.ats-altiscale", {
 
     artifact "spark", {
-      file "$gendir/src/spark_rpmbuild/rpm/sap-alti-spark-${buildVersion}.noarch.rpm"
+      file "$gendir/src/spark_rpmbuild/rpm/sap-alti-spark-${baseversion}.noarch.rpm"
     }
 
     artifact "spark-shuffle", {

--- a/sap-xmake-build.sh
+++ b/sap-xmake-build.sh
@@ -354,9 +354,10 @@ if [ $? -ne 0 ] ; then
 fi
 popd
 
-SAP_RPM_NAME="sap-${RPM_NAME}-${RELEASE}.noarch"
+SAP_RPM_NAME="sap-alti-spark-${SPARK_VERSION}-${RELEASE}.noarch"
 mv "${RPM_DIR}${RPM_NAME}-${SPARK_VERSION}-${RELEASE}.noarch.rpm" "${RPM_DIR}${SAP_RPM_NAME}.rpm"
-echo "ok - spark $RPM_NAME and RPM completed successfully!"
+echo "ok - spark $RPM_NAME completed successfully and created RPM ${RPM_DIR}${SAP_RPM_NAME}.rpm for export!"
+ls -al "${RPM_DIR}${SAP_RPM_NAME}.rpm"
 
 echo "ok - build completed successfully!"
 

--- a/sap-xmake-build.sh
+++ b/sap-xmake-build.sh
@@ -26,9 +26,9 @@ export HIVE_VERSION=${HIVE_VERSION:-"2.1.1"}
 export SPARK_PKG_NAME=${SPARK_PKG_NAME:-"spark"}
 export SPARK_GID=${SPARK_GID:-"411460017"}
 export SPARK_UID=${SPARK_UID:-"411460024"}
-# XMAKE_PROJECT_VERSION derived from cfg/VERSION file
-RELEASE=$(echo $XMAKE_PROJECT_VERSION | cut -d- -f2)
-export SPARK_VERSION=$(echo $XMAKE_PROJECT_VERSION | cut -d- -f1)
+# XMAKE_PROJECT_BASE_VERSION derived from cfg/VERSION file
+RELEASE=$(echo $XMAKE_PROJECT_BASE_VERSION | cut -d- -f2)
+export SPARK_VERSION=$(echo $XMAKE_PROJECT_BASE_VERSION | cut -d- -f1)
 export SCALA_VERSION=${SCALA_VERSION:-"2.11"}
 
 if [[ $SPARK_VERSION == 2.* ]] ; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Align generated RPM filename with `cfg/export.ads`.
Replace `XMAKE_PROJECT_VERSION ` with `XMAKE_PROJECT_BASE_VERSION` b/c it includes the branch name, and we don't want the branch name to be part of the RPM.

## How was this patch tested?

Since I didn't create a new CI pipeline for branch `alee-BDSGOLD-900-rename-rpm`. I simply r-create a new branch called `sap-branch-2.3.2-alti-SPARK-24570-patch` based on `sap-branch-2.3.2-alti` and then rebased it on `alee-BDSGOLD-900-rename-rpm` for testing purpose.
Re-using the existing CI xmake pipeline on this branch `sap-branch-2.3.2-alti-SPARK-24570-patch`
https://xmake-dev.wdf.sap.corp/job/ats-altiscale/job/ats-altiscale-spark-sap-branch-2.3.2-alti-SPARK-24570-patch-CI-dockerrun/

Test pass on https://xmake-dev.wdf.sap.corp/job/ats-altiscale/job/ats-altiscale-spark-sap-branch-2.3.2-alti-SPARK-24570-patch-CI-dockerrun/23/